### PR TITLE
bug: when multiple video blocks crossfade, only the first plays

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -180,16 +180,6 @@ const App = () => {
     return () => {
       if (videoMuteButton) videoMuteButton.removeEventListener("click", eventListener);
 
-      videos.forEach(video => {
-        try {
-          intersectionObserver.unobserve(video);
-          mutationObserver.unobserve(video)
-        } catch (e) {
-          // Sometimes videos disappear before we can unobserve them, especially
-          // during development
-        }
-      });
-
       intersectionObserver.disconnect();
       mutationObserver.disconnect();
     };


### PR DESCRIPTION
This works for the use case but it's not well tested.

1. should we have a clearer distinction between which videos use the mutation vs intersection observer?
2. need to double-check this isn't running the fade in/out vids multiple times.